### PR TITLE
fix: yaml file with array value returns parent

### DIFF
--- a/lib/issue-to-line/utils.ts
+++ b/lib/issue-to-line/utils.ts
@@ -82,7 +82,7 @@ function getNodeForPath(
   path: string,
 ): FileStructureNode | undefined {
   if (!path.includes('[')) {
-    return nodeValues.find((currNode) => currNode.key === path);
+    return nodeValues.find((currNode) => currNode.key.startsWith(path));
   }
 
   const [nodeName, subNodeName] = path.replace(']', '').split('[');

--- a/test/fixtures/multi.yaml
+++ b/test/fixtures/multi.yaml
@@ -108,3 +108,21 @@ spec:
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: MultiIssues
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  defaultAllowPrivilegeEscalation: true
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  runAsUser:
+    rule: RunAsAny
+  allowedCapabilities:
+    - ALL
+  requiredDropCapabilities:
+    - "SYS_ADMIN"

--- a/test/lib/yaml-parser.spec.ts
+++ b/test/lib/yaml-parser.spec.ts
@@ -149,6 +149,14 @@ describe('Yaml Parser', () => {
       issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(27);
   });
+
+  test('Ends with array returns the object itself', () => {
+    const path: string[] = ['[DocId: 2]', 'spec', 'allowedCapabilities'];
+
+    expect(
+      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+    ).toEqual(126);
+  });
 });
 
 describe('Yaml Parser - Single document', () => {


### PR DESCRIPTION
### What this does

Yaml parser where the entity it points on is array points on the parent and not the entity itself
CC Support ticket

- [Jira ticket CC-171](https://snyksec.atlassian.net/browse/CC-171)
- [Slack conversation](https://snyk.slack.com/archives/CS61093QC/p1588690923102800)
