### PR TITLE
fix: parsing issue in objects starting with equal

### DIFF
--- a/lib/issue-to-line/tf/parser.ts
+++ b/lib/issue-to-line/tf/parser.ts
@@ -201,7 +201,10 @@ function getSubTypeNode(
 }
 
 function getObjectNode(line: Line, stateQueue: TFState[]): FileStructureNode {
-  const key = line.content.split(Charts.openBracketsObject)[0].trim();
+  const key = line.content
+    .split(Charts.openBracketsObject)[0]
+    .split(Charts.equal)[0]
+    .trim();
   const objectNode: FileStructureNode = getNode(key, line);
 
   stateQueue.push({ structure: objectNode, type: TFLineTypes.OBJECT_START });

--- a/lib/issue-to-line/tf/utils.ts
+++ b/lib/issue-to-line/tf/utils.ts
@@ -99,15 +99,19 @@ export function getLineType(
     return TFLineTypes.MULTILINE_STRING;
   }
 
-  if (line.content.includes(Charts.equal)) {
-    return TFLineTypes.STRING;
-  }
-
   if (line.content.includes(Charts.openBracketsObject)) {
     if (line.content.includes(Charts.closeBracketsObject)) {
+      if (line.content.includes(Charts.equal)) {
+        return TFLineTypes.STRING;
+      }
+
       return TFLineTypes.OBJECT_START_AND_END;
     }
     return TFLineTypes.OBJECT_START;
+  }
+
+  if (line.content.includes(Charts.equal)) {
+    return TFLineTypes.STRING;
   }
 
   if (line.content.includes(Charts.closeBracketsObject)) {

--- a/test/fixtures/tf/single.tf
+++ b/test/fixtures/tf/single.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "allow_tcp" {
   description = "Allow TCP inbound from anywhere"
   vpc_id      = "${aws_vpc.main.id}"
 
-  ingress {
+  ingress = {
     from_port   = 3389
     to_port     = 3389
     protocol    = "tcp"


### PR DESCRIPTION
### What this does

Fix issue in parser where objects `name = {` were considered as string and not as object.

### More information

- [Jira ticket CC-249](https://snyksec.atlassian.net/browse/CC-249)
- [Slack conversation](https://snyk.slack.com/archives/C0160T60GNN/p1594694318017200)
