### PR TITLE
fix: empty document in yaml fail parsing

### DIFF
--- a/lib/issue-to-line/yaml/parser.ts
+++ b/lib/issue-to-line/yaml/parser.ts
@@ -29,7 +29,11 @@ export function buildYamlTreeMap(yamlContent: string): MapsDocIdToTree {
 
   for (let i = 0; i < docsArray.length; i++) {
     const yamlDoc: YamlNodeElement = convertComposeElementToType(docsArray[i]);
-    yamlTrees[i] = buildTree(yamlDoc);
+    // Handle case of empty document - the tag will be null
+    // No need to build tree for this document
+    if (yamlDoc.tag !== NULL_TAG) {
+      yamlTrees[i] = buildTree(yamlDoc);
+    }
   }
 
   return yamlTrees;

--- a/test/fixtures/yaml/multi.yaml
+++ b/test/fixtures/yaml/multi.yaml
@@ -126,3 +126,4 @@ spec:
     - ALL
   requiredDropCapabilities:
     - "SYS_ADMIN"
+---


### PR DESCRIPTION
### What this does

When trying to parse YAML file with empty doc - the parser was failing.
Now when we are building the yaml trees - we will ignore empty doc case and won't build a tree in this case.

### More information

- [Jira ticket CC-275](https://snyksec.atlassian.net/browse/CC-275)
