### PR TITLE
fix: terraform multi line array parsing issue

### DIFF
--- a/lib/issue-to-line/tf/utils.ts
+++ b/lib/issue-to-line/tf/utils.ts
@@ -125,6 +125,13 @@ export function getLineType(
     return TFLineTypes.MULTILINE_STRING;
   }
 
+  if (currentObjectType === TFLineTypes.ARRAY_START) {
+    // Handling case of multi-line array object where the content is not yet finished.
+    // Those lines will be skipped as part of
+    // https://github.com/snyk/cloud-config-parser/blob/b5f5bdd8dd60cb3ad9c110bb6c640f08db0e108b/lib/issue-to-line/tf/parser.ts#L44
+    return TFLineTypes.STRING;
+  }
+
   throw new SyntaxError('Invalid TF input - Unknown line type');
 }
 

--- a/test/fixtures/tf/single.tf
+++ b/test/fixtures/tf/single.tf
@@ -40,3 +40,18 @@ resource "aws_security_group" "allow_tcp" {
 }
 
 resource "aws_internet_gateway" "default" {}
+
+resource "aws_security_group" "with_multi_line_array" {
+  name        = "allow_tcp"
+  description = "Allow TCP inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress = {
+    from_port   = 3389
+    to_port     = 3389
+    protocol    = "tcp"
+    cidr_blocks = [
+      "::/0"
+    ]
+  }
+}


### PR DESCRIPTION
### What this does

Fix multi-line array parsing issue.
When an array object was
```
cidr_blocks = [
      "0.0.0.0/0",
    ]
```
We were expecting the start but not the middle.
So now we will refer the middle as a string and wait till the array will end.

### More information

- [Jira ticket SC-267](https://snyksec.atlassian.net/browse/CC-267)