### PR TITLE
feat: support terraform locals object

### DIFF
--- a/lib/issue-to-line/tf/parser.ts
+++ b/lib/issue-to-line/tf/parser.ts
@@ -1,5 +1,11 @@
 import { MapsDocIdToTree, FileStructureNode } from '../../types';
-import { TFLineTypes, TFState, MultiLinePhrase, Line } from './types';
+import {
+  TFLineTypes,
+  TFState,
+  MultiLinePhrase,
+  Line,
+  TerraformValidConfigurationTypes,
+} from './types';
 import {
   Charts,
   getLineState,
@@ -199,8 +205,8 @@ function getTypeDetailsFromLine(
   const objectType = lineContent[0];
 
   if (resourceType === Charts.openBracketsObject) {
-    if (objectType === 'terraform') {
-      //Support Terraform settings object
+    if (TerraformValidConfigurationTypes.includes(objectType)) {
+      //Support Terraform configurations settings object
       resourceType = '';
     } else {
       throw new SyntaxError('Invalid TF input - Type object without sub type');

--- a/lib/issue-to-line/tf/types.ts
+++ b/lib/issue-to-line/tf/types.ts
@@ -38,3 +38,5 @@ export interface TFState {
   structure: FileStructureNode;
   type: TFLineTypes;
 }
+
+export const TerraformValidConfigurationTypes = ['terraform', 'locals'];

--- a/test/fixtures/tf/with-terraform-object.tf
+++ b/test/fixtures/tf/with-terraform-object.tf
@@ -9,6 +9,14 @@ terraform {
   required_version = ">= 0.12.7"
 }
 
+locals {
+  common_tags = {
+    Service     = var.app_name
+    Environment = var.environment
+    Cost_Center = var.tag_cost_center
+  }
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # PREPARE PROVIDERS
 # ---------------------------------------------------------------------------------------------------------------------

--- a/test/lib/tf-parser.spec.ts
+++ b/test/lib/tf-parser.spec.ts
@@ -114,7 +114,18 @@ describe('TF Parser - File with terraform object', () => {
     ];
     expect(
       issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(62);
+    ).toEqual(70);
+  });
+});
+
+describe('TF Parser - File with locals object', () => {
+  const multiTF = 'test/fixtures/tf/with-terraform-object.tf';
+  const multiTFContent = readFileSync(multiTF).toString();
+  test('Locals object existence and parsable', () => {
+    const path: string[] = ['locals', 'common_tags', 'Service'];
+    expect(
+      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+    ).toEqual(12);
   });
 });
 


### PR DESCRIPTION
### What this does

Add `locals` object to be handled in similar to `terraform` object - as a unique object type that does not need a sub-type.

### More information

- [Jira ticket CC-383](https://snyksec.atlassian.net/browse/CC-383)
- [Slack thread](https://snyk.slack.com/archives/CRV0PMFDH/p1600440553002600)
- [Zendesk ticket](https://snyk.zendesk.com/agent/tickets/6689)
- [Locals documentation](https://www.terraform.io/docs/configuration/locals.html)
