### PR TITLE
chore: remove unused library

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "homepage": "https://github.com/snyk/snyk-config-parser#readme",
   "dependencies": {
     "esprima": "^4.0.1",
-    "source-map-support": "^0.5.16",
     "tslib": "^1.10.0",
     "yaml-js": "^0.3.0"
   },


### PR DESCRIPTION
There are no references to this library in the code, it is mostly
only used by applications. jest handles source-maps itself without
this dependency.
