### PR TITLE
feat: function object considered as regular object

### DIFF
--- a/lib/issue-to-line/tf/utils.ts
+++ b/lib/issue-to-line/tf/utils.ts
@@ -101,6 +101,13 @@ export function getLineType(
     return TFLineTypes.MULTILINE_STRING;
   }
 
+  if (line.content.includes(Charts.openFunction)) {
+    if (line.content.includes(Charts.closeFunction)) {
+      return TFLineTypes.FUNCTION_START_AND_END;
+    }
+    return TFLineTypes.FUNCTION_START;
+  }
+
   if (line.content.includes(Charts.openBracketsObject)) {
     if (line.content.includes(Charts.closeBracketsObject)) {
       if (line.content.includes(Charts.equal)) {
@@ -110,13 +117,6 @@ export function getLineType(
       return TFLineTypes.OBJECT_START_AND_END;
     }
     return TFLineTypes.OBJECT_START;
-  }
-
-  if (line.content.includes(Charts.openFunction)) {
-    if (line.content.includes(Charts.closeFunction)) {
-      return TFLineTypes.FUNCTION_START_AND_END;
-    }
-    return TFLineTypes.FUNCTION_START;
   }
 
   if (line.content.includes(Charts.closeFunction)) {

--- a/test/fixtures/tf/with-function-after-brackets.tf
+++ b/test/fixtures/tf/with-function-after-brackets.tf
@@ -1,0 +1,9 @@
+resource "aws_kms_key" "efs" {
+  description             = format("KMS key for EFS %s-%s-%s", var.environment, var.project, random_string.efs_prefix.result)
+  deletion_window_in_days = 7
+  is_enabled              = true
+  tags = merge(var.tags, {
+    "Name" = format("%s-%s-%s-key", var.environment, var.project, random_string.efs_prefix.result),
+    "type" = "kms",
+  })
+}

--- a/test/lib/tf-parser.spec.ts
+++ b/test/lib/tf-parser.spec.ts
@@ -149,6 +149,16 @@ describe('TF Parser - File with function object', () => {
       issuePathToLineNumber(functionTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(4);
   });
+
+  test('The correct line number is returned for issues found in file with function object', () => {
+    const functionTF = 'test/fixtures/tf/with-function-after-brackets.tf';
+    const functionTFContent = readFileSync(functionTF).toString();
+
+    const path: string[] = ['resource', 'aws_kms_key[efs]', 'is_enabled'];
+    expect(
+      issuePathToLineNumber(functionTFContent, CloudConfigFileTypes.TF, path),
+    ).toEqual(4);
+  });
 });
 
 describe('TF Parser - Broken TF', () => {


### PR DESCRIPTION
### What this does

As part of the problems discovered following the customer ticket,
We found out that in cases that there are functions and `(` in the same line - the `(` will be the first one we are referring to so we will think this is an `object` and not `function` as it really is.

This was the case we did not handler till now:
```
tags = merge(local.common_tags, {
    NpmTrigger   = null_resource.npm_installer.id,
    FunctionHash = data.archive_file.source_archive.output_base64sha256
  })
```

While we did handled:
```
tags = merge(
local.common_tags, 
  {
    NpmTrigger   = null_resource.npm_installer.id,
    FunctionHash = data.archive_file.source_archive.output_base64sha256
  },
)
```


### More information

- [Jira ticket CC-383](https://snyksec.atlassian.net/browse/CC-383)
- [Slack thread](https://snyk.slack.com/archives/CRV0PMFDH/p1600440553002600)
- [Zendesk ticket](https://snyk.zendesk.com/agent/tickets/6689)