### PR TITLE
fix: yaml first commented doc in multi-doc ignored

### DIFF
--- a/test/fixtures/yaml/multi_doc_with_commented_docs.yaml
+++ b/test/fixtures/yaml/multi_doc_with_commented_docs.yaml
@@ -1,0 +1,167 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:template", "template")
+#@ load("secrets.lib.yml","shared_config_volumes", "shared_config_volume_mounts", "ccng_config_mount_path", "ccng_secrets_mount_path")
+---
+#@ load("@ytt:data", "data")
+#@ load("@ytt:template", "template")
+#@ load("secrets.lib.yml","shared_config_volumes", "shared_config_volume_mounts", "ccng_config_mount_path", "ccng_secrets_mount_path")
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cf-api-server
+  namespace: #@ data.values.system_namespace
+spec:
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-server
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9102'
+      labels:
+        app.kubernetes.io/name: cf-api-server
+    spec:
+      #@ if/end data.values.imagePullSecrets:
+      imagePullSecrets: #@ data.values.imagePullSecrets
+      containers:
+        - name: cf-api-server
+          image: #@ data.values.images.ccng
+          command: ['/cnb/process/web']
+          env:
+            - name: CLOUD_CONTROLLER_NG_CONFIG
+              value: #@ ccng_config_mount_path
+            - name: CLOUD_CONTROLLER_NG_SECRETS
+              value: #@ ccng_secrets_mount_path
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 500m
+              memory: 300Mi
+            limits:
+              cpu: 1000m
+              memory: 1.2Gi
+          volumeMounts:
+            -  #@ template.replace(shared_config_volume_mounts())
+            - name: server-sock
+              mountPath: /data/cloud_controller_ng
+            - name: nginx-uploads
+              mountPath: /tmp/uploads
+            #@ if/end data.values.eirini.serverCerts.secretName:
+            - name: eirini-certs
+              mountPath: /config/eirini/certs
+            #@ if/end data.values.ccdb.ca_cert:
+            - name: database-ca-cert
+              mountPath: /config/database/certs
+        - name: cf-api-local-worker
+          image: #@ data.values.images.ccng
+          imagePullPolicy: Always
+          command: ['/cnb/process/local-worker']
+          env:
+            - name: CLOUD_CONTROLLER_NG_CONFIG
+              value: #@ ccng_config_mount_path
+            - name: CLOUD_CONTROLLER_NG_SECRETS
+              value: #@ ccng_secrets_mount_path
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 1.2Gi
+          volumeMounts:
+            -  #@ template.replace(shared_config_volume_mounts())
+            - name: nginx-uploads
+              mountPath: /tmp/uploads
+            - name: tmp-packages
+              mountPath: /tmp/packages
+            #@ if/end data.values.ccdb.ca_cert:
+            - name: database-ca-cert
+              mountPath: /config/database/certs
+        - name: registry-buddy
+          image: #@ data.values.images.registry_buddy
+          imagePullPolicy: Always
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+          volumeMounts:
+            - name: tmp-packages
+              mountPath: /tmp/packages
+          env:
+            - name: REGISTRY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cc-package-registry-upload-secret
+                  key: username
+            - name: REGISTRY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cc-package-registry-upload-secret
+                  key: password
+        - name: nginx
+          image: #@ data.values.images.nginx
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+            - containerPort: 9023
+          readinessProbe:
+            httpGet:
+              port: 80
+              path: '/healthz'
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: nginx
+              mountPath: /etc/nginx
+              readOnly: true
+            - name: server-sock
+              mountPath: /data/cloud_controller_ng
+            - name: nginx-logs
+              mountPath: /cloud_controller_ng
+            - name: nginx-uploads
+              mountPath: /tmp/uploads
+        - name: statsd-exporter
+          ports:
+            - containerPort: 9102
+          image: #@ data.values.images.statsd_exporter
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+      serviceAccountName: cf-api-server-service-account
+      volumes:
+        -  #@ template.replace(shared_config_volumes())
+        - name: server-sock
+          emptyDir: {}
+        - name: nginx
+          configMap:
+            name: nginx
+        - name: nginx-logs
+          emptyDir: {}
+        #@ if/end data.values.eirini.serverCerts.secretName:
+        - name: eirini-certs
+          secret:
+            secretName: #@ data.values.eirini.serverCerts.secretName
+        #@ if/end data.values.ccdb.ca_cert:
+        - name: database-ca-cert
+          secret:
+            secretName: database-ca-cert
+        - name: nginx-uploads
+          emptyDir: {}
+        - name: tmp-packages
+          emptyDir: {}

--- a/test/lib/yaml-parser.spec.ts
+++ b/test/lib/yaml-parser.spec.ts
@@ -232,3 +232,21 @@ describe('YAML Parser - broken YAMLs', () => {
     }
   });
 });
+
+describe('Yaml Parser - Multi-doc file with comments docs', () => {
+  const fileName = 'test/fixtures/yaml/multi_doc_with_commented_docs.yaml';
+  const yamlContent = readFileSync(fileName).toString();
+  test('test third object where the first two objects are comments only', () => {
+    const path: string[] = [
+      '[DocId: 2]',
+      'spec',
+      'selector',
+      'matchLabels',
+      'app.kubernetes.io/name',
+    ];
+
+    expect(
+      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+    ).toEqual(22);
+  });
+});


### PR DESCRIPTION
### What this does

When having a multi-doc Yaml file that starts with comments (before the ---), the existing tool that we are using is ignoring it and skip this document, so the order of the documents is changed.
So in this case where commented document and the number of documents is not fit and the UI will fail as a result.

### More information

- [Jira ticket CC-452](https://snyksec.atlassian.net/browse/CC-452)
- [Zendesk ticket](https://snyk.zendesk.com/agent/tickets/7341)
