### PR TITLE
fix: Gets correct node for paths that start with the same string

### DIFF
--- a/lib/issue-to-line/utils.ts
+++ b/lib/issue-to-line/utils.ts
@@ -1,8 +1,8 @@
 import {
   CloudConfigFileTypes,
-  PathDetails,
   FileStructureNode,
   LineLocation,
+  PathDetails,
 } from '../types';
 import { buildYamlTreeMap, getPathDetailsForYamlFile } from './yaml/parser';
 import { buildJsonTreeMap } from './json/parser';
@@ -84,7 +84,10 @@ function getNodeForPath(
   path: string,
 ): FileStructureNode | undefined {
   if (!path.includes('[')) {
-    return nodeValues.find((currNode) => currNode.key.startsWith(path));
+    return nodeValues.find(
+      (currNode) =>
+        currNode.key.startsWith(`${path}[`) || currNode.key === path,
+    );
   }
 
   const [nodeName, subNodeName] = path.replace(']', '').split('[');

--- a/test/fixtures/tf/with_two_references.tf
+++ b/test/fixtures/tf/with_two_references.tf
@@ -1,0 +1,20 @@
+resource "azurerm_virtual_machine" "denied_3" {
+  name                = "production"
+  resource_group_name = "networking"
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  os_profile {
+    custom_data = <<CUSTOM
+CUSTOM
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "denied_2" {
+  custom_data = <<CUSTOM
+eouireoiureioureiorueioraskdljsalkdjaskldjsakldjsalkdjsadasrerksmsd
+daklsdjklasjflskjraweoirewoirejwharoinasef
+CUSTOM
+}

--- a/test/lib/tf-parser.spec.ts
+++ b/test/lib/tf-parser.spec.ts
@@ -79,7 +79,7 @@ describe('TF Parser - Multiple resources', () => {
       'resource',
       'aws_security_group[allow_ssh_with_valid_cidr]',
       'ingress',
-      'cidr_block',
+      'cidr_blocks',
     ];
     expect(
       issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
@@ -158,6 +158,21 @@ describe('TF Parser - File with function object', () => {
     expect(
       issuePathToLineNumber(functionTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(4);
+  });
+
+  test('The correct line number is returned in the case of 2 fields starting with the same string', () => {
+    const fileName = 'test/fixtures/tf/with_two_references.tf';
+    const tfContent = readFileSync(fileName).toString();
+    const path: string[] = [
+      'resource',
+      'azurerm_virtual_machine[denied_3]',
+      'os_profile',
+      'admin_password',
+    ];
+
+    expect(
+      issuePathToLineNumber(tfContent, CloudConfigFileTypes.TF, path),
+    ).toEqual(9);
   });
 });
 


### PR DESCRIPTION
### What this does
This PR exists to fix a bug where were highlighting the wrong line number of an issue. The highlighting worked fine, but the problem was on the lineNumber we returned for that path. 

There is a bug where if we have a similar start of a string in a path e.g. `os_profile_something` and `os_profile`, it would return the first string it found in the contentFile (if the path was `spec->os_profile` but `spec->os_profile_something` was first in order in the contentFile, it would incorrectly return the line where the `os_profile_something` was).

This PR fixes that problem by returning the correct lineNumber and the highlighting to the path works as it should.

### Notes for the reviewer
The **getNodeForPath()** in the `utils.ts` file was checking if a node was starting with a string. We now fix that by checking if the currentNode is equal to the path We also added a startWith "path + [" for the cases where the yaml path ends with array and we want to return that object itself. This was correctly caught by [this test](https://github.com/snyk/cloud-config-parser/blob/9413a3e902fefd1b1bba025e61a8c0406cbc696e/test/lib/yaml-parser.spec.ts#L153) in the yaml-parser.

### More information

- [Jira ticket SC-566](https://snyksec.atlassian.net/browse/CC-566)

### Screenshots
**Before**
![image](https://user-images.githubusercontent.com/6989529/102216016-714f2a80-3ed2-11eb-8de9-10688fcec657.png)

**After**
![image](https://user-images.githubusercontent.com/6989529/102214965-ec174600-3ed0-11eb-8c8a-c382d534851f.png)
