### PR TITLE
fix: Minor change to trigger semantic release bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ Are 1 based!
 
 We are looking for the key in the path and not the value.
 
-For example - `drop` may have multiple values as an array of strings. We can show `drop[0]` as the first array of values but not `drop['192.168.0.1']`.
+For example , `drop` may have multiple values as an array of strings. We can show `drop[0]` as the first array of values but not `drop['192.168.0.1']`.


### PR DESCRIPTION
Updating Readme with a semantic prefix to trigger a new semantic release.

**Background**

When we migrated this repo to public, there was no new release published, and some public npm registry mirrors can not find this package. It is quite strange - the npm registry still shows it as public: https://www.npmjs.com/package/@snyk/cloud-config-parser

I believe that if we re-trigger a semantic release, it will show as a new package in NPM Registry, and then all the mirrors will read it as a public package accordingly.

This was flagged up as an issue when a user tried to install the Snyk CLI https://github.com/snyk/snyk/issues/2064