### PR TITLE
feat: split issuePathToLineNumber into getTrees and getLinenumber [CC-1021]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,29 @@ This library is being used as part of snyk cloud configuration product.
 
 ## How it works
 
-The library receives a path (array of strings), a file type (YAML/JSON/HCL), and the configuration file content and it returns the number of the line which is the closest to the path received.
-In case that the full path does not exist - the returned line number will correspond to the deepest entry in the path array that was found.
+The library has two main methods:
+1. `getTrees` - this function receives a fileType and a configuration fileContent and builds the relevant tree (FileStructureTree). An example tree would look like this:
+```   
+   '0': {
+      nodes: [
+         {
+            key: 'apiVersion',
+            lineLocation: {
+            columnEnd: 14,
+            columnStart: 4,
+            line: 2,
+         },
+         values: [...],
+         {...},
+      ],
+   '1': {...}
+   ...
+   },
+   ```
+2. `getLineNumber`- this function receives a path (array of strings) , a fileType (YAML/JSON/HCL), and a tree and returns the number of the line which is the closest to the path received.
+   In case that the full path does not exist, the returned line number will correspond to the deepest entry in the path array that was found.
 
+The function `issuesToLineNumbers` invokes both of them: it will build the tree by parsing the fileContent and then return the lineNumber.
 
 ## Examples:  
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,3 @@
 export { CloudConfigFileTypes } from './types';
 
-export { issuePathToLineNumber as issuesToLineNumbers } from './issue-to-line';
+export { issuesToLineNumbers, getTrees, getLineNumber } from './issue-to-line';

--- a/lib/issue-to-line/index.ts
+++ b/lib/issue-to-line/index.ts
@@ -4,21 +4,39 @@ import {
   getPathDetails,
   findLineNumberOfGivenPath,
 } from './utils';
+import { CloudConfigFileTypes, MapsDocIdToTree } from '../types';
 
-export function issuePathToLineNumber(
+export function issuesToLineNumbers(
   fileContent: string,
   fileType: types.CloudConfigFileTypes,
   path: string[],
 ): number {
-  if (!Object.values(types.CloudConfigFileTypes).includes(fileType)) {
-    throw new Error('Unknown format');
-  }
+  const trees = getTrees(fileType, fileContent);
+  return getLineNumber(path, fileType, trees);
+}
 
+export function getTrees(fileType: CloudConfigFileTypes, fileContent: string) {
+  assertFileType(fileType);
   const trees = buildTreeForTypeMap[fileType](fileContent);
   if (Object.keys(trees).length === 0) {
     throw new Error('failed to create trees');
   }
+  return trees;
+}
+
+export function getLineNumber(
+  path: string[],
+  fileType: CloudConfigFileTypes,
+  trees: MapsDocIdToTree,
+) {
+  assertFileType(fileType);
   const pathDetails = getPathDetails(path.slice(), fileType);
   const treeNodes: types.FileStructureNode[] = trees[pathDetails.docId].nodes;
   return findLineNumberOfGivenPath(treeNodes, pathDetails);
+}
+
+function assertFileType(fileType: CloudConfigFileTypes) {
+  if (!Object.values(types.CloudConfigFileTypes).includes(fileType)) {
+    throw new Error('Unknown format');
+  }
 }

--- a/lib/issue-to-line/utils.ts
+++ b/lib/issue-to-line/utils.ts
@@ -4,6 +4,7 @@ import {
   LineLocation,
   PathDetails,
 } from '../types';
+import { YamlNodeElement } from './yaml/types';
 import { buildYamlTreeMap, getPathDetailsForYamlFile } from './yaml/parser';
 import { buildJsonTreeMap } from './json/parser';
 import { buildTfTreeMap } from './tf/parser';

--- a/lib/issue-to-line/yaml/parser.ts
+++ b/lib/issue-to-line/yaml/parser.ts
@@ -6,6 +6,7 @@ import {
   PathDetails,
 } from '../../types';
 import { getLineLocationForYamlElement, removeInputPathPrefix } from '../utils';
+import { CommentObject, YamlNodeElement } from './types';
 
 const NULL_TAG = 'tag:yaml.org,2002:null';
 const STR_TAG = 'tag:yaml.org,2002:str';
@@ -23,7 +24,7 @@ const MULTI_DOC_SEPARATOR = '---';
 
 export function buildYamlTreeMap(yamlContent: string): MapsDocIdToTree {
   const yamlTrees: MapsDocIdToTree = {};
-  let docsArray = [];
+  let docsArray: CommentObject[] = [];
   try {
     docsArray = yamlJs.compose_all(yamlContent);
   } catch (error) {
@@ -39,8 +40,8 @@ export function buildYamlTreeMap(yamlContent: string): MapsDocIdToTree {
     yamlContent.split(MULTI_DOC_SEPARATOR).length === docsArray.length + 1
   ) {
     /* eslint-disable @typescript-eslint/camelcase */
-    // Disable calmecale  - object structure from yamlJs
-    const commentObject = {
+    // Disable camelcase  - object structure from yamlJs
+    const commentObject: CommentObject = {
       start_mark: { line: 0, column: 0, pointer: 0, buffer: yamlContent },
       end_mark: { line: 0, column: 0, pointer: 0, buffer: yamlContent },
       style: undefined,

--- a/lib/issue-to-line/yaml/types.ts
+++ b/lib/issue-to-line/yaml/types.ts
@@ -7,12 +7,21 @@ type TagTypes =
   | 'tag:yaml.org,2002:map'
   | 'tag:yaml.org,2002:seq';
 
-interface YamlNodeElement {
+export interface YamlNodeElement {
   id: string;
   tag: TagTypes;
   startMark: YamlMark;
   endMark: YamlMark;
   value: string | any[] | Array<[any, any]>;
+}
+
+export interface CommentObject {
+  start_mark: Record<any, any>;
+  end_mark: Record<any, any>;
+  style: any;
+  tag: string;
+  unique_id: string;
+  value: string;
 }
 
 interface YamlMark {

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -1,4 +1,4 @@
-import { issuePathToLineNumber } from '../../lib/issue-to-line';
+import { issuesToLineNumbers } from '../../lib/issue-to-line';
 import { CloudConfigFileTypes } from '../../lib/types';
 
 const dumyFileContent = 'dumy';
@@ -7,7 +7,7 @@ const dumyPath = ['dumy'];
 describe('issuePathToLineNumber', () => {
   test('Unsupported type', () => {
     expect(() => {
-      issuePathToLineNumber(
+      issuesToLineNumbers(
         dumyFileContent,
         CloudConfigFileTypes.JSON + 100,
         dumyPath,

--- a/test/lib/json-parser.spec.ts
+++ b/test/lib/json-parser.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { issuePathToLineNumber } from '../../lib/issue-to-line/index';
+import { issuesToLineNumbers } from '../../lib/issue-to-line/index';
 import { CloudConfigFileTypes } from '../../lib/types';
 
 describe('JSON Parser - working JSONS', () => {
@@ -10,7 +10,7 @@ describe('JSON Parser - working JSONS', () => {
     const path: string[] = ['spec', 'selector', 'app.kubernetes.io/name'];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(19);
   });
 
@@ -18,7 +18,7 @@ describe('JSON Parser - working JSONS', () => {
     const path: string[] = ['spec', 'selector', 'app.kubernetes.io/notExist'];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(18);
   });
 
@@ -33,7 +33,7 @@ describe('JSON Parser - working JSONS', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(56);
   });
 
@@ -48,7 +48,7 @@ describe('JSON Parser - working JSONS', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(56);
   });
 
@@ -64,7 +64,7 @@ describe('JSON Parser - working JSONS', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(58);
   });
 
@@ -80,7 +80,7 @@ describe('JSON Parser - working JSONS', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(90);
   });
 
@@ -95,7 +95,7 @@ describe('JSON Parser - working JSONS', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(55);
   });
 
@@ -110,7 +110,7 @@ describe('JSON Parser - working JSONS', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleJsonContent, CloudConfigFileTypes.JSON, path),
+      issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
     ).toEqual(31);
   });
 });
@@ -122,7 +122,7 @@ describe('JSON Parser - broken JSONS', () => {
     const filePath = 'test/fixtures/json/broken-object.json';
     const fileContent = readFileSync(filePath).toString();
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.JSON, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.JSON, path);
     }).toThrowError('unexpected end of JSON input');
   });
 
@@ -133,7 +133,7 @@ describe('JSON Parser - broken JSONS', () => {
     const fileContent = readFileSync(filePath).toString();
 
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.JSON, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.JSON, path);
     }).toThrowError('unexpected end of JSON input');
   });
 
@@ -144,7 +144,7 @@ describe('JSON Parser - broken JSONS', () => {
     const fileContent = readFileSync(filePath).toString();
 
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.JSON, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.JSON, path);
     }).toThrowError('unexpected end of JSON input');
   });
 
@@ -152,7 +152,7 @@ describe('JSON Parser - broken JSONS', () => {
     const path: string[] = ['specs'];
 
     expect(() => {
-      issuePathToLineNumber('', CloudConfigFileTypes.JSON, path);
+      issuesToLineNumbers('', CloudConfigFileTypes.JSON, path);
     }).toThrowError('unexpected end of JSON input');
   });
 
@@ -162,7 +162,7 @@ describe('JSON Parser - broken JSONS', () => {
     const InvalidChars = ['', ' ', '{', '['];
     for (const brokenJson of InvalidChars) {
       expect(() => {
-        issuePathToLineNumber(brokenJson, CloudConfigFileTypes.JSON, path);
+        issuesToLineNumbers(brokenJson, CloudConfigFileTypes.JSON, path);
       }).toThrowError('unexpected end of JSON input');
     }
   });
@@ -173,7 +173,7 @@ describe('JSON Parser - broken JSONS', () => {
     const InvalidChars = ["'", '"'];
     for (const brokenJson of InvalidChars) {
       expect(() => {
-        issuePathToLineNumber(brokenJson, CloudConfigFileTypes.JSON, path);
+        issuesToLineNumbers(brokenJson, CloudConfigFileTypes.JSON, path);
       }).toThrowError('Line 1: Unexpected token ILLEGAL');
     }
   });
@@ -184,7 +184,7 @@ describe('JSON Parser - broken JSONS', () => {
     const InvalidChars = ['}', ']'];
     for (const brokenJson of InvalidChars) {
       expect(() => {
-        issuePathToLineNumber(brokenJson, CloudConfigFileTypes.JSON, path);
+        issuesToLineNumbers(brokenJson, CloudConfigFileTypes.JSON, path);
       }).toThrowError('failed to find type Punctuator');
     }
   });

--- a/test/lib/tf-parser.spec.ts
+++ b/test/lib/tf-parser.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { issuePathToLineNumber } from '../../lib/issue-to-line/index';
+import { issuesToLineNumbers } from '../../lib/issue-to-line/index';
 import { CloudConfigFileTypes } from '../../lib/types';
 
 describe('TF Parser - working TF file with comments - single resource', () => {
@@ -14,7 +14,7 @@ describe('TF Parser - working TF file with comments - single resource', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(simpleTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(19);
   });
 
@@ -27,7 +27,7 @@ describe('TF Parser - working TF file with comments - single resource', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(simpleTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(25);
   });
 
@@ -40,7 +40,7 @@ describe('TF Parser - working TF file with comments - single resource', () => {
     ];
 
     expect(
-      issuePathToLineNumber(simpleTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(simpleTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(28);
   });
 
@@ -48,7 +48,7 @@ describe('TF Parser - working TF file with comments - single resource', () => {
     const path: string[] = ['provider', 'aws', 'region'];
 
     expect(
-      issuePathToLineNumber(simpleTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(simpleTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(3);
   });
 });
@@ -59,7 +59,7 @@ describe('TF Parser - Multiple resources', () => {
   test('First resource in multi resource env', () => {
     const path: string[] = ['resource', 'aws_vpc[default]', 'cidr_block'];
     expect(
-      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(8);
   });
 
@@ -70,7 +70,7 @@ describe('TF Parser - Multiple resources', () => {
       'vpc_id',
     ];
     expect(
-      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(13);
   });
 
@@ -82,7 +82,7 @@ describe('TF Parser - Multiple resources', () => {
       'cidr_blocks',
     ];
     expect(
-      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(38);
   });
 
@@ -90,7 +90,7 @@ describe('TF Parser - Multiple resources', () => {
     const path: string[] = ['provider', 'aws', 'region'];
 
     expect(
-      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(3);
   });
 });
@@ -101,7 +101,7 @@ describe('TF Parser - File with terraform object', () => {
   test('Terraform object', () => {
     const path: string[] = ['terraform', 'required_version'];
     expect(
-      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(6);
   });
 
@@ -113,7 +113,7 @@ describe('TF Parser - File with terraform object', () => {
       'cidr_blocks',
     ];
     expect(
-      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(70);
   });
 });
@@ -124,7 +124,7 @@ describe('TF Parser - File with locals object', () => {
   test('Locals object existence and parsable', () => {
     const path: string[] = ['locals', 'common_tags', 'Service'];
     expect(
-      issuePathToLineNumber(multiTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(12);
   });
 });
@@ -136,7 +136,7 @@ describe('TF Parser - File with function object', () => {
 
     const path: string[] = ['resource', 'aws_kms_key[efs]', 'is_enabled'];
     expect(
-      issuePathToLineNumber(functionTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(functionTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(4);
   });
 
@@ -146,7 +146,7 @@ describe('TF Parser - File with function object', () => {
 
     const path: string[] = ['resource', 'aws_kms_key[efs]', 'is_enabled'];
     expect(
-      issuePathToLineNumber(functionTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(functionTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(4);
   });
 
@@ -156,7 +156,7 @@ describe('TF Parser - File with function object', () => {
 
     const path: string[] = ['resource', 'aws_kms_key[efs]', 'is_enabled'];
     expect(
-      issuePathToLineNumber(functionTFContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(functionTFContent, CloudConfigFileTypes.TF, path),
     ).toEqual(4);
   });
 
@@ -171,7 +171,7 @@ describe('TF Parser - File with function object', () => {
     ];
 
     expect(
-      issuePathToLineNumber(tfContent, CloudConfigFileTypes.TF, path),
+      issuesToLineNumbers(tfContent, CloudConfigFileTypes.TF, path),
     ).toEqual(9);
   });
 });
@@ -187,7 +187,7 @@ describe('TF Parser - Broken TF', () => {
     const filePath = 'test/fixtures/tf/broken-object.tf';
     const fileContent = readFileSync(filePath).toString();
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.TF, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.TF, path);
     }).toThrowError('Invalid TF input');
   });
 
@@ -201,7 +201,7 @@ describe('TF Parser - Broken TF', () => {
     const filePath = 'test/fixtures/tf/broken-invalid-type.tf';
     const fileContent = readFileSync(filePath).toString();
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.TF, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.TF, path);
     }).toThrowError('Invalid TF input');
   });
 
@@ -209,7 +209,7 @@ describe('TF Parser - Broken TF', () => {
     const path: string[] = ['resource', 'aws_security_group[allow_tcp]'];
 
     expect(() => {
-      issuePathToLineNumber('', CloudConfigFileTypes.TF, path);
+      issuesToLineNumbers('', CloudConfigFileTypes.TF, path);
     }).toThrowError('Invalid TF input');
   });
 });

--- a/test/lib/yaml-parser.spec.ts
+++ b/test/lib/yaml-parser.spec.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'fs';
-import { issuePathToLineNumber } from '../../lib/issue-to-line/index';
-import { CloudConfigFileTypes } from '../../lib/types';
+import { issuesToLineNumbers, CloudConfigFileTypes } from '../../lib';
 
 describe('Yaml Parser', () => {
   const fileName = 'test/fixtures/yaml/multi.yaml';
@@ -15,7 +14,7 @@ describe('Yaml Parser', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(27);
   });
 
@@ -28,7 +27,7 @@ describe('Yaml Parser', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(26);
   });
 
@@ -45,7 +44,7 @@ describe('Yaml Parser', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(75);
   });
 
@@ -62,7 +61,7 @@ describe('Yaml Parser', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(75);
   });
 
@@ -80,7 +79,7 @@ describe('Yaml Parser', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(78);
   });
 
@@ -97,7 +96,7 @@ describe('Yaml Parser', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(74);
   });
 
@@ -114,7 +113,7 @@ describe('Yaml Parser', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(55);
   });
 
@@ -122,7 +121,7 @@ describe('Yaml Parser', () => {
     const path: string[] = ['[DocId: 0]', 'specs'];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(2);
   });
 
@@ -130,7 +129,7 @@ describe('Yaml Parser', () => {
     const path: string[] = ['[DocId: 0]', 'specs', 'selector'];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(2);
   });
 
@@ -138,7 +137,7 @@ describe('Yaml Parser', () => {
     const path: string[] = ['[DocId: 1]', 'specs'];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(31);
   });
 
@@ -146,7 +145,7 @@ describe('Yaml Parser', () => {
     const path: string[] = ['spec', 'selector', 'app.kubernetes.io/name'];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(27);
   });
 
@@ -154,7 +153,7 @@ describe('Yaml Parser', () => {
     const path: string[] = ['[DocId: 2]', 'spec', 'allowedCapabilities'];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(126);
   });
 });
@@ -172,7 +171,7 @@ describe('Yaml Parser - Single document', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(27);
   });
 });
@@ -184,7 +183,7 @@ describe('YAML Parser - broken YAMLs', () => {
     const filePath = 'test/fixtures/yaml/broken-object.yaml';
     const fileContent = readFileSync(filePath).toString();
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.YAML, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.YAML, path);
     }).not.toThrow();
   });
 
@@ -195,7 +194,7 @@ describe('YAML Parser - broken YAMLs', () => {
     const fileContent = readFileSync(filePath).toString();
 
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.YAML, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.YAML, path);
     }).toThrowError('failed to compose_all for given yaml');
   });
 
@@ -206,7 +205,7 @@ describe('YAML Parser - broken YAMLs', () => {
     const fileContent = readFileSync(filePath).toString();
 
     expect(() => {
-      issuePathToLineNumber(fileContent, CloudConfigFileTypes.YAML, path);
+      issuesToLineNumbers(fileContent, CloudConfigFileTypes.YAML, path);
     }).not.toThrow();
   });
 
@@ -216,7 +215,7 @@ describe('YAML Parser - broken YAMLs', () => {
     const InvalidChars = ['', ' '];
     for (const brokenJson of InvalidChars) {
       expect(() => {
-        issuePathToLineNumber(brokenJson, CloudConfigFileTypes.YAML, path);
+        issuesToLineNumbers(brokenJson, CloudConfigFileTypes.YAML, path);
       }).toThrowError('failed to create trees');
     }
   });
@@ -227,7 +226,7 @@ describe('YAML Parser - broken YAMLs', () => {
     const InvalidChars = ['"', '{', '[', '}', ']', "'"];
     for (const brokenJson of InvalidChars) {
       expect(() => {
-        issuePathToLineNumber(brokenJson, CloudConfigFileTypes.YAML, path);
+        issuesToLineNumbers(brokenJson, CloudConfigFileTypes.YAML, path);
       }).toThrowError('failed to compose_all for given yaml');
     }
   });
@@ -246,7 +245,7 @@ describe('Yaml Parser - Multi-doc file with comments docs', () => {
     ];
 
     expect(
-      issuePathToLineNumber(yamlContent, CloudConfigFileTypes.YAML, path),
+      issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
     ).toEqual(22);
   });
 });


### PR DESCRIPTION
### What this does

This PR refactors the `issuePathToLineNumber` into two functions; one to build the tree and one to get the line for the given path.

The reason behind this is that there are use cases that we need to get the line number without having to re-build the tree.

It is also cleaner in code.

### Notes for the reviewer

- Check the first commit for code changes.
- The second commit is just a rename of the function from `issuePathToLineNumber` to `issuesToLineNumbers`, as this is what is aliased as in index. There is no particular need for that alias.

