### PR TITLE
fix: package.json with correct github url

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk/snyk-config-parser"
+    "url": "https://github.com/snyk/cloud-config-parser"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "bin",
     "dist"
   ],
-  "homepage": "https://github.com/snyk/snyk-config-parser#readme",
+  "homepage": "https://github.com/snyk/cloud-config-parser#readme",
   "dependencies": {
     "esprima": "^4.0.1",
     "tslib": "^1.10.0",


### PR DESCRIPTION
### What this does

The github url is outdated and this is not being picked up in various places, like Snyk Advisor: https://snyk.io/advisor/npm-package/@snyk/cloud-config-parser

![image](https://user-images.githubusercontent.com/6989529/128035715-595e48fa-b415-4410-9a35-d1760baf3ee5.png)
