### PR TITLE
refactor: expose MapsDocIdToTree

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,3 @@
-export { CloudConfigFileTypes } from './types';
+export { CloudConfigFileTypes, MapsDocIdToTree } from './types';
 
 export { issuesToLineNumbers, getTrees, getLineNumber } from './issue-to-line';


### PR DESCRIPTION
### What this does

This PR exposes `MapsDocIdToTree` type, so it won't be needed to pick from `dist/types` folder.

Currently, when we use the `cloud-config-parser`, and want to use types from it when try to import `MapsDocIdToTree` it takes the type from within the dependency folder.
But similar type `CloudConfigFileTypes` we do expose.
This PR aligns between those types and expose `MapsDocIdToTree` for better and simple use.