### PR TITLE
feat: add custom yaml parsing [CC-1012]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 A utility library for identifying the issue path in a YAML/JSON/HCL file and returning the relevant line number in order to highlight the relevant line to the users in their files.
 
+It also exposes a customised YAML parser.
+
 This library is being used as part of snyk cloud configuration product.
 
 ## How it works
 
-The library has two main methods:
+The library has three main methods:
 1. `getTrees` - this function receives a fileType and a configuration fileContent and builds the relevant tree (FileStructureTree). An example tree would look like this:
 ```   
    '0': {
@@ -32,6 +34,10 @@ The library has two main methods:
    In case that the full path does not exist, the returned line number will correspond to the deepest entry in the path array that was found.
 
 The function `issuesToLineNumbers` invokes both of them: it will build the tree by parsing the fileContent and then return the lineNumber.
+
+3. `parseFileContent`- this function receives the contents of a file and returns the parsed JSON representation of the contents.
+   The file contents can be either YAML or JSON.
+   **Note** This parser uses a different underlying parser to the `getTrees` function - the implementation of `getTrees` will change once we replace the `yaml-js` parser with this one.
 
 ## Examples:  
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
 export { CloudConfigFileTypes, MapsDocIdToTree } from './types';
 
 export { issuesToLineNumbers, getTrees, getLineNumber } from './issue-to-line';
+
+export { parseFileContent } from './yaml-parser';

--- a/lib/yaml-parser/index.ts
+++ b/lib/yaml-parser/index.ts
@@ -1,0 +1,36 @@
+import * as YAML from 'yaml';
+
+export function parseFileContent(fileContent: string): any[] {
+  // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
+  // by using this library we don't have to disambiguate between these different contents ourselves
+  return YAML.parseAllDocuments(fileContent).map((doc) => {
+    if (shouldThrowErrorFor(doc)) {
+      throw doc.errors[0];
+    }
+    if (showThrowWarningFor(doc)) {
+      throw doc.warnings[0];
+    }
+    return doc.toJSON();
+  });
+}
+
+function shouldThrowErrorFor(doc: YAML.Document.Parsed) {
+  const errorsToSkip = [
+    'Insufficient indentation in flow collection',
+    'Map keys must be unique',
+  ];
+  return (
+    doc.errors.length !== 0 &&
+    !errorsToSkip.some((e) => doc.errors[0].message.includes(e))
+  );
+}
+
+function showThrowWarningFor(doc: YAML.Document.Parsed) {
+  const warningsToInclude = [
+    'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.',
+  ];
+  return (
+    doc.warnings.length !== 0 &&
+    warningsToInclude.some((e) => doc.warnings[0].message.includes(e))
+  );
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "esprima": "^4.0.1",
     "tslib": "^1.10.0",
+    "yaml": "^1.10.2",
     "yaml-js": "^0.3.0"
   },
   "devDependencies": {

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -1,3 +1,4 @@
+import { parseFileContent } from '../../lib';
 import { issuesToLineNumbers } from '../../lib/issue-to-line';
 import { CloudConfigFileTypes } from '../../lib/types';
 
@@ -5,7 +6,7 @@ const dumyFileContent = 'dumy';
 const dumyPath = ['dumy'];
 
 describe('issuePathToLineNumber', () => {
-  test('Unsupported type', () => {
+  it('Throws an error for unsupported type', () => {
     expect(() => {
       issuesToLineNumbers(
         dumyFileContent,
@@ -13,5 +14,89 @@ describe('issuePathToLineNumber', () => {
         dumyPath,
       );
     }).toThrowError('Unknown format');
+  });
+});
+
+describe('parseFileContent', () => {
+  it('Throws an error if keys are not simple strings', () => {
+    expect(() => {
+      parseFileContent(`---
+{ foo: "bar"}: bar`);
+    }).toThrowError(
+      'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.',
+    );
+  });
+
+  it('Succeeds even if there is insufficient indentation', () => {
+    expect(
+      parseFileContent(`---
+foo:
+  bar:
+    enum: [
+      "abc",
+      "cde"
+    ]`),
+    ).toEqual([
+      {
+        foo: {
+          bar: {
+            enum: ['abc', 'cde'],
+          },
+        },
+      },
+    ]);
+  });
+
+  it('Succeeds even if keys are not unique', () => {
+    expect(
+      parseFileContent(`---
+    foo: "bar"
+    "foo": "baz"`),
+    ).toEqual([
+      {
+        foo: 'baz',
+      },
+    ]);
+  });
+
+  it('Succeeds for valid YAML', () => {
+    expect(
+      parseFileContent(`---
+foo: "bar"`),
+    ).toEqual([
+      {
+        foo: 'bar',
+      },
+    ]);
+  });
+
+  it('Succeeds for valid multi-file YAML', () => {
+    expect(
+      parseFileContent(`---
+foo: "bar"
+---
+foo: "baz"`),
+    ).toEqual([
+      {
+        foo: 'bar',
+      },
+      {
+        foo: 'baz',
+      },
+    ]);
+  });
+
+  it('Succeeds for valid JSON', () => {
+    expect(parseFileContent('{"foo": "bar"}')).toEqual([
+      {
+        foo: 'bar',
+      },
+    ]);
+  });
+
+  it('Fails for invalid JSON', () => {
+    expect(() => {
+      parseFileContent('{"foo": "bar"');
+    }).toThrowError('Expected flow map to end with }');
   });
 });


### PR DESCRIPTION
### What this does

In order to extract the custom YAML parsing logic from the many places we use it as part of https://snyksec.atlassian.net/browse/CC-1012, we first need to move it to a library. This library has parsing logic, for generating the line number for files. But it can also contain this custom parsing logic. 

### Notes for the reviewer
Run:
1. `npm run build`
2. `npm link`


Clone https://github.com/snyk/snyk/ and change to `feat/replace-yaml-parser`.
Run:
1. `npm link @snyk/cloud-config-parser`
2. `npm run build`
3. ` snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-privileged.yaml`
4. `snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-valid.json`

This tests both JSON and YAML and so verifies that the parsing still works.

<img width="819" alt="Screenshot 2021-09-16 at 16 45 45" src="https://user-images.githubusercontent.com/81559517/133623569-dd7d81b4-086b-468d-892c-5425375d4ed6.png">
<img width="732" alt="Screenshot 2021-09-16 at 16 45 49" src="https://user-images.githubusercontent.com/81559517/133623582-6edbcd17-1782-4e98-9362-abb5bac686c9.png">
