### PR TITLE
fix: inconsistency with yaml parsing

### DIFF
--- a/lib/yaml-parser/index.ts
+++ b/lib/yaml-parser/index.ts
@@ -1,6 +1,10 @@
 import * as YAML from 'yaml';
 
 export function parseFileContent(fileContent: string): any[] {
+  // YAML should fail on \/ but the library doesn't: https://snyksec.atlassian.net/browse/CC-1175
+  if (fileContent.includes('\\/')) {
+    throw new Error('Found escape character \\/.');
+  }
   // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
   // by using this library we don't have to disambiguate between these different contents ourselves
   return YAML.parseAllDocuments(fileContent).map((doc) => {

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -18,6 +18,16 @@ describe('issuePathToLineNumber', () => {
 });
 
 describe('parseFileContent', () => {
+  it('Throws an error if it contains \\/', () => {
+    /* eslint-disable no-useless-escape */
+    expect(() => {
+      parseFileContent(`{
+  "foo": "\\/"
+}`);
+    }).toThrowError('Found escape character \\/.');
+    /* eslint-enable no-useless-escape */
+  });
+
   it('Throws an error if keys are not simple strings', () => {
     expect(() => {
       parseFileContent(`---


### PR DESCRIPTION
### What this does

As per https://snyksec.atlassian.net/browse/CC-1175, throws and error if `\/` can be found when parsing YAML/JSON.

This is to maintain consistency when parsing YAML between Golang and JavaScript. The Golang parser returns the following error, so now the JavaScript one does too:
<img width="994" alt="Screenshot 2021-09-20 at 12 09 39" src="https://user-images.githubusercontent.com/81559517/133979356-7026a5bc-a27a-44a1-bc53-8ebd4dc8e271.png">

