### PR TITLE
chore: fix release process by updating Node.js version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   resource_class: small
   docker:
-    - image: node:10
+    - image: node:14-buster
   working_directory: ~/snyk-config-parser
 
 commands:
@@ -61,7 +61,7 @@ jobs:
   test:
     <<: *defaults
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14-buster
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
### What this does

The CircleCI workflow for creating a GitHub release has failed:
https://app.circleci.com/pipelines/github/snyk/cloud-config-parser/180/workflows/8c35cf26-82f9-414b-adaf-ab7802106cbc/jobs/495
The error is:
```
npx semantic-release
npx: installed 576 in 14.914s
[semantic-release]: node version >=14.17 is required. Found v10.24.1.

See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.
```

### Notes for the reviewer

In other Snyk repos we use `circleci/node:14-buster` so this PR updates the version.