### PR TITLE
feat: add path parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 ![Snyk logo](https://snyk.io/style/asset/logo/snyk-print.svg)
 
-***
+---
+
 # Snyk cloud-config-parser
 
-A utility library for identifying the issue path in a YAML/JSON/HCL file and returning the relevant line number in order to highlight the relevant line to the users in their files.
+A utility library that support Snyk IaC parsing.
+The two supported types of functionalities are:
+
+1. Identify issue path in a cloud config file.
+2. Parse a serialized string issue path into an array for use with the `getLineNumber()` function.
+
+## Identify issue path in a cloud config file.
+
+Identifying the issue path in a YAML/JSON/HCL file and returning the relevant line number in order to highlight the relevant line to the users in their files.
 
 It also exposes a customised YAML parser.
 
 This library is being used as part of snyk cloud configuration product.
 
-## How it works
+### How it works
 
 The library has three main methods:
+
 1. `getTrees` - this function receives a fileType and a configuration fileContent and builds the relevant tree (FileStructureTree). An example tree would look like this:
-```   
+
+```
    '0': {
       nodes: [
          {
@@ -29,7 +40,8 @@ The library has three main methods:
    '1': {...}
    ...
    },
-   ```
+```
+
 2. `getLineNumber`- this function receives a path (array of strings) , a fileType (YAML/JSON/HCL), and a tree and returns the number of the line which is the closest to the path received.
    In case that the full path does not exist, the returned line number will correspond to the deepest entry in the path array that was found.
 
@@ -39,59 +51,85 @@ The function `issuesToLineNumbers` invokes both of them: it will build the tree 
    The file contents can be either YAML or JSON.
    **Note** This parser uses a different underlying parser to the `getTrees` function - the implementation of `getTrees` will change once we replace the `yaml-js` parser with this one.
 
-## Examples:  
+### Examples:
 
 ---
 
-For the received path: 
+For the received path:
 
-- ```['spec', 'template', 'spec', 'containers[0]', 'nonExistingResource', 'securityContext', 'capabilities']``` 
+- `['spec', 'template', 'spec', 'containers[0]', 'nonExistingResource', 'securityContext', 'capabilities']`
 
 It will return the line number of the first element in the containers array (because nonExistingResource does not exist).
 
-For the received path: 
+For the received path:
 
-- ```['spec', 'template', 'spec', 'containers[0]', 'resources', 'securityContext', 'capabilities']```
+- `['spec', 'template', 'spec', 'containers[0]', 'resources', 'securityContext', 'capabilities']`
 
 It will return the line number of 'capabilities'.
 
+#### Elements with array:
 
-### Elements with array:
 ---
 
-Until now, the paths received in the Cloud Config issues were `containers[snyky1]`, where `snyky1` was the value of the `name` property in one of the objects in `containers`.  
+Until now, the paths received in the Cloud Config issues were `containers[snyky1]`, where `snyky1` was the value of the `name` property in one of the objects in `containers`.
 
 We are supporting both `containers[snyky1]` and `containers[0]`, while the new issues will be in the format of `containers[0]`.
 
-The piece of code that creates the paths is creating elements like `containers[0]`, but in cases of `containers[snyky1]`, it goes over the elements of the array and looks for a sub-element with key: `name` and value `snyky1`.  
+The piece of code that creates the paths is creating elements like `containers[0]`, but in cases of `containers[snyky1]`, it goes over the elements of the array and looks for a sub-element with key: `name` and value `snyky1`.
 
+#### **Paths starting with 'input'**
 
-### **Paths starting with 'input'**  
 ---
 
-For example:  
+For example:
 
-```['input', 'spec', 'template', 'spec', 'containers[0]', 'resources', 'securityContext', 'capabilities']```
+`['input', 'spec', 'template', 'spec', 'containers[0]', 'resources', 'securityContext', 'capabilities']`
 
-The input value will be removed and the path we are looking for will be like this:  
+The input value will be removed and the path we are looking for will be like this:
 
-```['spec', 'template', 'spec', 'containers[0]', 'resources', 'securityContext', 'capabilities']```
+`['spec', 'template', 'spec', 'containers[0]', 'resources', 'securityContext', 'capabilities']`
 
-### **Yaml DocId:**
+#### **YAML DocId:**
+
 ---
 
-- In the case that the files are JSON or single Yaml - the `DocId` will be `0`.  
-- In the case of a multi-document file - the `DocId` will be according to the order of the documets.
+- In the case that the files are JSON or single YAML - the `DocId` will be `0`.
+- In the case of a multi-document file - the `DocId` will be according to the order of the documents.
 
+#### Line numbers
 
-### Line numbers
 ---
+
 Are 1 based!
 
+#### Keys - not value
 
-### Keys - not value
 ---
 
 We are looking for the key in the path and not the value.
 
 For example , `drop` may have multiple values as an array of strings. We can show `drop[0]` as the first array of values but not `drop['192.168.0.1']`.
+
+## Parse serialized issue path for use in `getLineNumber()`.
+
+This parser get an issue path and returns array of it's components.
+The parser split by `.`, unless the object is inside brackets and then it remain it as single object
+
+### Example:
+
+1. **Input:** foo
+   **Output:** ['foo']
+2. **Input:** foo.bar.baz
+   **Output:** ['foo', 'bar', 'baz']
+3. **Input:** foo_1.\_bar2.baz3\_
+   **Output:** ['foo\_1', '\_bar2', 'baz3\_']
+4. **Input:** foo.bar[abc].baz
+   **Output:** ['foo', 'bar[abc]', 'baz']
+5. **Input:** foo.bar[abc.def].baz
+   **Output:** ['foo', 'bar[abc.def]', 'baz']
+6. **Input:** foo.bar['abc.def'].baz
+   **Output:** ['foo', "bar['abc.def']", 'baz']
+7. **Input:** foo.bar["abc.def"].baz
+   **Output:** ['foo', 'bar["abc.def"]', 'baz']
+8. **Input:** foo.bar['abc/def'].baz
+   **Output:** ['foo', "bar['abc/def']", 'baz']

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,3 +3,5 @@ export { CloudConfigFileTypes, MapsDocIdToTree } from './types';
 export { issuesToLineNumbers, getTrees, getLineNumber } from './issue-to-line';
 
 export { parseFileContent } from './yaml-parser';
+
+export { parsePath } from './parsers/path';

--- a/lib/parsers/path.ts
+++ b/lib/parsers/path.ts
@@ -1,0 +1,37 @@
+import * as peggy from 'peggy';
+
+const grammar = `
+// Documentation, specifically for parsing delimited lists.
+// https://peggyjs.org/documentation#parsing-lists
+
+// A path is a dot delimeted list of identifiers.
+path = head:segment tail:("." @segment)* { return [head, ...tail]; }
+
+// Segments consist of an identifier and an optional index.
+// e.g. hello or hello[world]
+segment = $(identifier index?)
+
+// An identifier is a string of consecutive characters not consisting of dots, quotes or brackets. 
+identifier = [^'"\\[\\]\\.]+
+
+// An index consists of square brackets containing a quoted or unquoted value.
+// e.g. hello['world'] or hello[world]
+index = "[" $( unquoted_index / single_quoted_index / double_quoted_index) "]"
+
+unquoted_index = [^'"\\]\\[]+
+single_quoted_index = "'" [^']+ "'"
+double_quoted_index = '"' [^"]+ '"'
+`;
+
+export const parsePath = createPathParser();
+
+function createPathParser(): (expr: string) => string[] {
+  const parser = peggy.generate(grammar);
+  return (expr: string) => {
+    try {
+      return parser.parse(expr);
+    } catch (e) {
+      return expr.split('.');
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/snyk/cloud-config-parser#readme",
   "dependencies": {
     "esprima": "^4.0.1",
+    "peggy": "^1.2.0",
     "tslib": "^1.10.0",
     "yaml": "^1.10.2",
     "yaml-js": "^0.3.0"

--- a/test/lib/parsers/path.spec.ts
+++ b/test/lib/parsers/path.spec.ts
@@ -1,0 +1,21 @@
+import { parsePath } from '../../../lib/parsers/path';
+
+describe('parsing issue path', () => {
+  it.each([
+    ['foo', ['foo']],
+    ['foo.bar.baz', ['foo', 'bar', 'baz']],
+    ['foo_1._bar2.baz3_', ['foo_1', '_bar2', 'baz3_']],
+    ['foo.bar[abc].baz', ['foo', 'bar[abc]', 'baz']],
+    ['foo.bar[abc.def].baz', ['foo', 'bar[abc.def]', 'baz']],
+    ["foo.bar['abc.def'].baz", ['foo', "bar['abc.def']", 'baz']],
+    ['foo.bar["abc.def"].baz', ['foo', 'bar["abc.def"]', 'baz']],
+    ["foo.bar['abc/def'].baz", ['foo', "bar['abc/def']", 'baz']],
+    ["foo.bar['abcdef'].baz", ['foo', "bar['abcdef']", 'baz']],
+    ["bar['abc.def']", ["bar['abc.def']"]],
+    ["fo%o.bar['ab$c/def'].baz", ['fo%o', "bar['ab$c/def']", 'baz']],
+    ['foo.hello["world[\'1\']"]', ['foo', 'hello["world[\'1\']"]']],
+    ['foo.hello[\'world"]]', ['foo', 'hello[\'world"]]']],
+  ])('%s', (input, expected) => {
+    expect(parsePath(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
### What this does

This PR adds a second type of parser - Issue path.
It takes an issue path and splits it by its components.
We are adding this functionality to this library so it could be used in all the places that use the IaC parser.

For example:
`foo.bar.baz` will be split to `['foo', 'bar', 'baz']`
`foo.bar[abc.def].baz` will be split to `['foo', 'bar[abc.def]', 'baz']`

