### PR TITLE
fix: allow escape characters in json parsing [CFG-1322]

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,6 @@ export { CloudConfigFileTypes, MapsDocIdToTree } from './types';
 
 export { issuesToLineNumbers, getTrees, getLineNumber } from './issue-to-line';
 
-export { parseFileContent } from './yaml-parser';
+export { ParserFileType, parseFileContent } from './yaml-parser';
 
 export { parsePath } from './parsers/path';

--- a/lib/yaml-parser/index.ts
+++ b/lib/yaml-parser/index.ts
@@ -1,8 +1,13 @@
 import * as YAML from 'yaml';
 
-export function parseFileContent(fileContent: string): any[] {
+export type ParserFileType = 'json' | 'yaml' | 'yml';
+
+export function parseFileContent(
+  fileContent: string,
+  fileType: ParserFileType = 'yaml',
+): any[] {
   // YAML should fail on \/ but the library doesn't: https://snyksec.atlassian.net/browse/CC-1175
-  if (fileContent.includes('\\/')) {
+  if (fileContent.includes('\\/') && fileType !== 'json') {
     throw new Error('Found escape character \\/.');
   }
   // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -18,14 +18,44 @@ describe('issuePathToLineNumber', () => {
 });
 
 describe('parseFileContent', () => {
-  it('Throws an error if it contains \\/', () => {
+  it('Throws an error if no file type provided and it contains \\/', () => {
     /* eslint-disable no-useless-escape */
     expect(() => {
-      parseFileContent(`{
-  "foo": "\\/"
-}`);
+      parseFileContent(`foo: "\\/"`);
     }).toThrowError('Found escape character \\/.');
     /* eslint-enable no-useless-escape */
+  });
+
+  it('Throws an error if YAML and it contains \\/', () => {
+    /* eslint-disable no-useless-escape */
+    expect(() => {
+      parseFileContent(`foo: "\\/"`, 'yaml');
+    }).toThrowError('Found escape character \\/.');
+    /* eslint-enable no-useless-escape */
+  });
+
+  it('Throws an error if YAML and it contains \\/', () => {
+    /* eslint-disable no-useless-escape */
+    expect(() => {
+      parseFileContent(`foo: "\\/"`, 'yml');
+    }).toThrowError('Found escape character \\/.');
+    /* eslint-enable no-useless-escape */
+  });
+
+  it('Succeeds an error if JSON and it contains \\/', () => {
+    /* eslint-disable no-useless-escape */
+    expect(
+      parseFileContent(
+        `{
+  "foo": "\\/"
+}`,
+        'json',
+      ),
+    ).toEqual([
+      {
+        foo: '/', // "\\/" is the equivalent of '/'
+      },
+    ]);
   });
 
   it('Throws an error if keys are not simple strings', () => {


### PR DESCRIPTION
### What this does
This PR fixes the bug in https://snyksec.atlassian.net/browse/CFG-1322 by making sure if the parsed file is JSON we don't fail upon finding `\\/`. A while ago we combined the parsing for JSON and YAML to both use the YAML parser, since they are more or less the same. We know from https://snyksec.atlassian.net/browse/CFG-364, however, that `\\/` is not valid YAML - and we added this check that throws an error when a YAML/JSON file contains `\\/`. Now, we're improving this logic so that if the content is JSON, we don't throw an error.

### Notes for the reviewer

Another option would be to start using `JSON` for the JSON parsing but for now I don't see the benefit of it. If we have to add any more edge cases then it might be worth considering.

The change in this PR falls back on the previous behaviour, treating anything that doesn't pass the `fileType` as YAML and so throwing the error if `\\/` is found.

In this branch:
1. `npm run build`
2. `npm link`

In  https://github.com/snyk/snyk/pull/2526:
1. `npm run build`
2. Create a file `test.json` containing:
```
{
      "DescribePackagesFilterValue":{
        "type":"string",
        "pattern":"^[0-9a-zA-Z\\*\\.\\\\/\\?-]*$"
      }
}
```
3. Run `snyk iac test test.json` - see an error about failed to parse JSON file
4. Run `snyk-dev iac test test.json` - see an error about no valid IaC files (in the customer's case it would just be ignored)

I will update the library in all consuming services.

### Screenshots
`snyk iac test test.json`
![Screenshot 2022-01-06 at 13 38 21](https://user-images.githubusercontent.com/81559517/148391349-e6123bb9-ae54-4b47-8e74-3351babd5a8e.png)

![Screenshot 2022-01-06 at 12 09 22](https://user-images.githubusercontent.com/81559517/148391129-18eb730e-6410-48b3-af86-0774251bb7e5.png)

`snyk-dev iac test test.json`
![Screenshot 2022-01-06 at 13 38 24](https://user-images.githubusercontent.com/81559517/148391354-6c1cfd17-1348-4651-b6da-0c609f009f6c.png)

![Screenshot 2022-01-06 at 12 11 57](https://user-images.githubusercontent.com/81559517/148391151-0556f24b-d62d-4406-a0b7-6f4aab7b2014.png)

