### PR TITLE
fix: return -1 for a lineNumber if path cant be matched

### DIFF
--- a/lib/issue-to-line/utils.ts
+++ b/lib/issue-to-line/utils.ts
@@ -43,8 +43,8 @@ export function findLineNumberOfGivenPath(
     (node) => node.key === pathDetails.path[0],
   );
   if (filteredNodes.length === 0) {
-    //Not exists
-    return nodes[0].lineLocation.line;
+    // If the path does not exist, we will return '-1'
+    return -1;
   }
 
   if (pathDetails.path.length === 1) {
@@ -69,8 +69,8 @@ function getLineNumberForSingleNode(
 
     const nodeForPath = getNodeForPath(node.values, remainingPath[0]);
     if (!nodeForPath) {
-      //Not exists
-      return node.lineLocation.line;
+      // If the path does not exist, we will return '-1'
+      return -1;
     }
 
     node = nodeForPath;

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -30,7 +30,7 @@ describe('issuePathToLineNumber', () => {
       issuesToLineNumbers(cloudformationContent, CloudConfigFileTypes.YAML, [
         'path',
       ]),
-    ).toEqual(2);
+    ).toEqual(-1);
   });
 });
 

--- a/test/lib/json-parser.spec.ts
+++ b/test/lib/json-parser.spec.ts
@@ -19,7 +19,7 @@ describe('JSON Parser - working JSONS', () => {
 
     expect(
       issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
-    ).toEqual(18);
+    ).toEqual(-1);
   });
 
   test('Path with array - full path exists', () => {
@@ -96,7 +96,7 @@ describe('JSON Parser - working JSONS', () => {
 
     expect(
       issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
-    ).toEqual(55);
+    ).toEqual(-1);
   });
 
   test('Path with array - full path not exists - stops at array', () => {
@@ -111,7 +111,7 @@ describe('JSON Parser - working JSONS', () => {
 
     expect(
       issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
-    ).toEqual(31);
+    ).toEqual(-1);
   });
 });
 

--- a/test/lib/tf-parser.spec.ts
+++ b/test/lib/tf-parser.spec.ts
@@ -41,7 +41,7 @@ describe('TF Parser - working TF file with comments - single resource', () => {
 
     expect(
       issuesToLineNumbers(simpleTFContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(28);
+    ).toEqual(-1);
   });
 
   test('Path provider - type without name', () => {
@@ -102,7 +102,7 @@ describe('TF Parser - File with terraform object', () => {
     const path: string[] = ['terraform', 'required_version'];
     expect(
       issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(6);
+    ).toEqual(-1);
   });
 
   test('Terraform object', () => {
@@ -125,7 +125,7 @@ describe('TF Parser - File with locals object', () => {
     const path: string[] = ['locals', 'common_tags', 'Service'];
     expect(
       issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(12);
+    ).toEqual(-1);
   });
 });
 
@@ -172,7 +172,7 @@ describe('TF Parser - File with function object', () => {
 
     expect(
       issuesToLineNumbers(tfContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(9);
+    ).toEqual(-1);
   });
 });
 

--- a/test/lib/yaml-parser.spec.ts
+++ b/test/lib/yaml-parser.spec.ts
@@ -28,7 +28,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(26);
+    ).toEqual(-1);
   });
 
   test('Path with array - full path exists', () => {
@@ -97,7 +97,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(74);
+    ).toEqual(-1);
   });
 
   test('Path with array - full path not exists - stops at array', () => {
@@ -114,7 +114,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(55);
+    ).toEqual(-1);
   });
 
   test('Path without array - path not exists - 1 item', () => {
@@ -122,7 +122,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(2);
+    ).toEqual(-1);
   });
 
   test('Path not exists - 1 item, on first document', () => {
@@ -130,7 +130,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(2);
+    ).toEqual(-1);
   });
 
   test('Path not exists - 1 item, on second document', () => {
@@ -138,7 +138,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(31);
+    ).toEqual(-1);
   });
 
   test('No DocId - default DocId: 0', () => {


### PR DESCRIPTION
### What this does

We simply return `-1` if we can not find a match for the path on the issue, instead of returning the first node as it used to be.

[CFG-1781]


[CFG-1781]: https://snyksec.atlassian.net/browse/CFG-1781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ