### PR TITLE
fix: revert single node linenumber

### DIFF
--- a/lib/issue-to-line/utils.ts
+++ b/lib/issue-to-line/utils.ts
@@ -69,8 +69,8 @@ function getLineNumberForSingleNode(
 
     const nodeForPath = getNodeForPath(node.values, remainingPath[0]);
     if (!nodeForPath) {
-      // If the path does not exist, we will return '-1'
-      return -1;
+      //Not exists
+      return node.lineLocation.line;
     }
 
     node = nodeForPath;

--- a/test/lib/json-parser.spec.ts
+++ b/test/lib/json-parser.spec.ts
@@ -19,7 +19,7 @@ describe('JSON Parser - working JSONS', () => {
 
     expect(
       issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
-    ).toEqual(-1);
+    ).toEqual(18);
   });
 
   test('Path with array - full path exists', () => {
@@ -96,7 +96,7 @@ describe('JSON Parser - working JSONS', () => {
 
     expect(
       issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
-    ).toEqual(-1);
+    ).toEqual(55);
   });
 
   test('Path with array - full path not exists - stops at array', () => {
@@ -111,7 +111,7 @@ describe('JSON Parser - working JSONS', () => {
 
     expect(
       issuesToLineNumbers(simpleJsonContent, CloudConfigFileTypes.JSON, path),
-    ).toEqual(-1);
+    ).toEqual(31);
   });
 });
 

--- a/test/lib/tf-parser.spec.ts
+++ b/test/lib/tf-parser.spec.ts
@@ -41,7 +41,7 @@ describe('TF Parser - working TF file with comments - single resource', () => {
 
     expect(
       issuesToLineNumbers(simpleTFContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(-1);
+    ).toEqual(28);
   });
 
   test('Path provider - type without name', () => {
@@ -102,7 +102,7 @@ describe('TF Parser - File with terraform object', () => {
     const path: string[] = ['terraform', 'required_version'];
     expect(
       issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(-1);
+    ).toEqual(6);
   });
 
   test('Terraform object', () => {
@@ -125,7 +125,7 @@ describe('TF Parser - File with locals object', () => {
     const path: string[] = ['locals', 'common_tags', 'Service'];
     expect(
       issuesToLineNumbers(multiTFContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(-1);
+    ).toEqual(12);
   });
 });
 
@@ -172,7 +172,7 @@ describe('TF Parser - File with function object', () => {
 
     expect(
       issuesToLineNumbers(tfContent, CloudConfigFileTypes.TF, path),
-    ).toEqual(-1);
+    ).toEqual(9);
   });
 });
 

--- a/test/lib/yaml-parser.spec.ts
+++ b/test/lib/yaml-parser.spec.ts
@@ -28,7 +28,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(-1);
+    ).toEqual(26);
   });
 
   test('Path with array - full path exists', () => {
@@ -97,7 +97,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(-1);
+    ).toEqual(74);
   });
 
   test('Path with array - full path not exists - stops at array', () => {
@@ -114,7 +114,7 @@ describe('Yaml Parser', () => {
 
     expect(
       issuesToLineNumbers(yamlContent, CloudConfigFileTypes.YAML, path),
-    ).toEqual(-1);
+    ).toEqual(55);
   });
 
   test('Path without array - path not exists - 1 item', () => {


### PR DESCRIPTION
### What this does

Reverting this change as it doesn't do exactly what we thought on https://github.com/snyk/cloud-config-parser/pull/42#discussion_r855393933. We thought that this line would find the nearest path in the middle of a tree if there's a single node, so in the previous PR, we updated it to also return -1 when the path could not be found exactly.

### Notes for the reviewer

Before
![image](https://user-images.githubusercontent.com/6989529/166907880-a1732ca7-19e7-4d0d-a68b-00464641fe7e.png)


After

![image](https://user-images.githubusercontent.com/6989529/166907902-48d11104-e332-48aa-b6b3-6897c19d0031.png)

