### PR TITLE
fix: disable opiniated error on YAML escape char

### DIFF
--- a/lib/yaml-parser/index.ts
+++ b/lib/yaml-parser/index.ts
@@ -2,14 +2,7 @@ import * as YAML from 'yaml';
 
 export type ParserFileType = 'json' | 'yaml' | 'yml';
 
-export function parseFileContent(
-  fileContent: string,
-  fileType: ParserFileType = 'yaml',
-): any[] {
-  // YAML should fail on \/ but the library doesn't: https://snyksec.atlassian.net/browse/CC-1175
-  if (fileContent.includes('\\/') && fileType !== 'json') {
-    throw new Error('Found escape character \\/.');
-  }
+export function parseFileContent(fileContent: string): any[] {
   // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
   // by using this library we don't have to disambiguate between these different contents ourselves
   return YAML.parseAllDocuments(fileContent).map((doc) => {

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -35,39 +35,12 @@ describe('issuePathToLineNumber', () => {
 });
 
 describe('parseFileContent', () => {
-  it('Throws an error if no file type provided and it contains \\/', () => {
-    /* eslint-disable no-useless-escape */
-    expect(() => {
-      parseFileContent(`foo: "\\/"`);
-    }).toThrowError('Found escape character \\/.');
-    /* eslint-enable no-useless-escape */
-  });
-
-  it('Throws an error if YAML and it contains \\/', () => {
-    /* eslint-disable no-useless-escape */
-    expect(() => {
-      parseFileContent(`foo: "\\/"`, 'yaml');
-    }).toThrowError('Found escape character \\/.');
-    /* eslint-enable no-useless-escape */
-  });
-
-  it('Throws an error if YAML and it contains \\/', () => {
-    /* eslint-disable no-useless-escape */
-    expect(() => {
-      parseFileContent(`foo: "\\/"`, 'yml');
-    }).toThrowError('Found escape character \\/.');
-    /* eslint-enable no-useless-escape */
-  });
-
-  it('Succeeds an error if JSON and it contains \\/', () => {
+  it('Succeeds if YAML and it contains \\/', () => {
     /* eslint-disable no-useless-escape */
     expect(
-      parseFileContent(
-        `{
-  "foo": "\\/"
-}`,
-        'json',
-      ),
+      parseFileContent(`{
+"foo": "\\/"
+}`),
     ).toEqual([
       {
         foo: '/', // "\\/" is the equivalent of '/'


### PR DESCRIPTION
### What this does

I suggest we revert the error we put in place a few months ago, when we thought that `\\/` would not be valid YAML. 
This used to be the case in YAML 1.1, but not in YAML 1.2. We can still parse this with the YAML parser and produce results.

### Notes for the reviewer

I have tested locally with this branch in the CLI: https://github.com/snyk/cli/tree/chore/update-cc-parser-yaml

and we do not flag this as an issue anymore.
