### PR TITLE
docs: fix YAML syntax error in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     github.com/project-slug: snyk/cloud-config-parser
     circleci.com/project-slug: github/snyk/cloud-config-parser
-  description: <
+  description: >
     A TypeScript library that exposes functions for parsing Infrastructure as Code configuration files for computing the line number.
   labels:
     snyk.io/businessCriticality: low


### PR DESCRIPTION
The `<` is the wrong way around :) https://yaml-multiline.info