### PR TITLE
fix: use JSON.parse to avoid OOM error

### DIFF
--- a/lib/yaml-parser/index.ts
+++ b/lib/yaml-parser/index.ts
@@ -2,9 +2,16 @@ import * as YAML from 'yaml';
 
 export type ParserFileType = 'json' | 'yaml' | 'yml';
 
-export function parseFileContent(fileContent: string): any[] {
+export function parseFileContent(
+  fileContent: string,
+  fileType: ParserFileType = 'yaml',
+): any[] {
   // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
-  // by using this library we don't have to disambiguate between these different contents ourselves
+  // but the YAML library uses a lot of memory which could cause the Node heap to run out of memory: https://snyk.zendesk.com/agent/tickets/35401
+  if (fileType === 'json') {
+    return [JSON.parse(fileContent)];
+  }
+
   return YAML.parseAllDocuments(fileContent).map((doc) => {
     if (shouldThrowErrorFor(doc)) {
       throw doc.errors[0];

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -38,9 +38,12 @@ describe('parseFileContent', () => {
   it('Succeeds if YAML and it contains \\/', () => {
     /* eslint-disable no-useless-escape */
     expect(
-      parseFileContent(`{
+      parseFileContent(
+        `{
 "foo": "\\/"
-}`),
+}`,
+        'json',
+      ),
     ).toEqual([
       {
         foo: '/', // "\\/" is the equivalent of '/'
@@ -50,11 +53,12 @@ describe('parseFileContent', () => {
 
   it('Throws an error if keys are not simple strings', () => {
     expect(() => {
-      parseFileContent(`---
-{ foo: "bar"}: bar`);
-    }).toThrowError(
-      'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.',
-    );
+      parseFileContent(
+        `---
+{ foo: "bar"}: bar`,
+        'json',
+      );
+    }).toThrowError('Unexpected number in JSON at position 1');
   });
 
   it('Succeeds even if there is insufficient indentation', () => {


### PR DESCRIPTION
### What this does
This PR fixes an OOM error thrown in Linux distributions only when using the YAML parser to parse huge JSON files. It does that by using the JSON parser instead. The bug would still be there for huge YAML files but, as we know, we will eventually deprecate this flow and this library in favour of the parsing logic in https://github.com/snyk/policy-engine

### Notes for the reviewer
We found that using the YAML library (https://github.com/eemeli/yaml) for both YAML and JSON parsing is the cause of the issue. The YAML library causes the Node heap to run out of memory, whereas the JSON library doesn't. Looking at past tickets and PRs, it seems the only reason we use the YAML library for both YAML and JSON is because it is able to parse both and it made the code simpler: https://github.com/snyk/cli/pull/2041 and https://snyksec.atlassian.net/browse/CFG-937. 

To test it, run `npm run build; npm run link` in this repo then in the CLI repo run:
1. `npm link @snyk/cloud-config-parser`
2. `npm run build`
Download the `latest.zip` file from the repo then run `snyk-dev iac test --severity-threshold=high cdk.out/`:
![Screenshot 2022-12-05 at 10 39 30](https://user-images.githubusercontent.com/81559517/205617197-c53b5554-38c8-4152-b816-30a128a494d7.png)
<img width="1496" alt="Screenshot 2022-12-05 at 10 42 39" src="https://user-images.githubusercontent.com/81559517/205617858-b4c2d3e3-d0c8-4576-b740-b75c6e2d15e4.png">


This shows that it works both on my MacOS and Linux.

Ticket: https://snyk.zendesk.com/agent/tickets/35401
Thread: https://snyk.slack.com/archives/CRV0PMFDH/p1669742627800659