### PR TITLE
fix: pin babel traverse while typescript bug is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "yaml-js": "^0.3.0"
   },
   "devDependencies": {
+    "@types/babel__traverse": "7.18.2",
     "@types/esprima": "^4.0.2",
     "@types/jest": "^25.1.1",
     "@types/node": "^12.12.26",


### PR DESCRIPTION
### What this does

Pins `babel__traverse` to unblock bug fix i nhttps://github.com/snyk/cloud-config-parser/pull/47.

### Notes for the reviewer

Bug: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/63431