### PR TITLE
fix: TS build errors

### DIFF
--- a/lib/yaml-parser/index.ts
+++ b/lib/yaml-parser/index.ts
@@ -12,7 +12,11 @@ export function parseFileContent(
     return [JSON.parse(fileContent)];
   }
 
-  return YAML.parseAllDocuments(fileContent).map((doc) => {
+  const documents = YAML.parseAllDocuments(fileContent) as YAML.Document.Parsed<
+    YAML.ParsedNode
+  >[];
+
+  return documents.map((doc) => {
     if (shouldThrowErrorFor(doc)) {
       throw doc.errors[0];
     }


### PR DESCRIPTION
This commit fixes 2 errors that were caused when running 'tsc':

1. lib/yaml-parser/index.ts:15:46 - error TS2349: This expression is not callable. .... has signatures, but none of those signatures are compatible with each other.

2. return YAML.parseAllDocuments(fileContent).map((doc) => { ~~~ lib/yaml-parser/index.ts:15:51 - error TS7006: Parameter 'doc' implicitly has an 'any' type.

doc.toJSON() returns 'any' so that's something we can not change. However, we can cast the parseAllDocuments() result to the expected type YAML.Document.Parsed<YAML.ParsedNode>[]. Then map won't complain about incompatibility of signatures.

Run `npm run bild` and tsc is ran successfully.
![image](https://github.com/snyk/cloud-config-parser/assets/6989529/51e15d28-185c-486e-a967-6a143d18cfbb)
