### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,9 @@ jobs:
           command: npm run build
       - run:
           name: Release on GitHub
-          command: npx semantic-release
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release
   security-scans:
     <<: *defaults
     steps:
@@ -146,7 +148,9 @@ workflows:
           <<: *only_branches
       - release:
           name: Release to GitHub
-          context: nodejs-lib-release
+          context:
+            - nodejs-install
+            - github-release
           requires:
           - Scan Repository for Secrets
           filters:


### PR DESCRIPTION
### What this does

This PR switches the NPM package publishing to short-lived OIDC tokens:

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_
